### PR TITLE
update Hokusai to v0.5.8 and interpolate template variables 

### DIFF
--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,6 +1,8 @@
 ---
 project-name: hokusai-sandbox
 git-remote: git@github.com:artsy/hokusai-sandbox.git
-hokusai-required-version: ">=0.5.6"
+hokusai-required-version: ">=0.5.8"
 pre-deploy: echo Ohai
 post-deploy: echo Bai
+template-config-files:
+  - s3://artsy-citadel/k8s/hokusai-vars.yml

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,3 +1,5 @@
+# prettier-ignore
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -2,17 +2,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hokusai-sandbox-web
+  name: {{ project_name }}-web
   namespace: default
   labels:
-    app: hokusai-sandbox
+    app: {{ project_name }}
     component: web
     layer: application
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
-      app: hokusai-sandbox
+      app: {{ project_name }}
       component: web
       layer: application
   strategy:
@@ -23,21 +23,21 @@ spec:
   template:
     metadata:
       labels:
-        app: hokusai-sandbox
+        app: {{ project_name }}
         component: web
         layer: application
-      name: hokusai-sandbox-web
+      name: {{ project_name }}-web
     spec:
       containers:
-        - name: hokusai-sandbox-web
-          envFrom:
-            - configMapRef:
-                name: hokusai-sandbox-environment
-          image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/hokusai-sandbox:production
-          imagePullPolicy: Always
-          ports:
-            - name: http
-              containerPort: 8080
+      - envFrom:
+        - configMapRef:
+            name: {{ project_name }}-environment
+        image: {{ project_repo }}:production
+        imagePullPolicy: Always
+        name: {{ project_name }}-web
+        ports:
+        - name: http
+          containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -47,13 +47,13 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
   labels:
-    app: hokusai-sandbox
+    app: {{ project_name }}
     component: web
     layer: application
-  name: hokusai-sandbox-web
+  name: {{ project_name }}-web
   namespace: default
 spec:
   ports:
@@ -66,7 +66,7 @@ spec:
     protocol: TCP
     targetPort: http
   selector:
-    app: hokusai-sandbox
+    app: {{ project_name }}
     component: web
     layer: application
   sessionAffinity: None

--- a/hokusai/staging-canary.yml
+++ b/hokusai/staging-canary.yml
@@ -2,13 +2,13 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: hokusai-sandbox-web-canary
+  name: {{ project_name }}-web-canary
   namespace: default
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: hokusai-sandbox-canary
+      app: {{ project_name }}-canary
       component: web
       layer: application
   strategy:
@@ -19,10 +19,10 @@ spec:
   template:
     metadata:
       labels:
-        app: hokusai-sandbox-canary
+        app: {{ project_name }}-canary
         component: web
         layer: application
-      name: hokusai-sandbox-web-canary
+      name: {{ project_name }}-web-canary
     spec:
       containers:
       - env:
@@ -30,10 +30,10 @@ spec:
             value: "3000"
         envFrom:
         - configMapRef:
-            name: hokusai-sandbox-environment
-        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/hokusai-sandbox:staging
+            name: {{ project_name }}-environment
+        image: {{ project_repo }}:staging
         imagePullPolicy: Always
-        name: hokusai-sandbox-web
+        name: {{ project_name }}-web
         ports:
         - name: http
           containerPort: 3000

--- a/hokusai/staging-canary.yml
+++ b/hokusai/staging-canary.yml
@@ -1,3 +1,5 @@
+# prettier-ignore
+
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -1,18 +1,20 @@
+# prettier-ignore
+
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hokusai-sandbox-web
+  name: {{ project_name }}-web
   namespace: default
   labels:
-    app: hokusai-sandbox
+    app: {{ project_name }}
     component: web
     layer: application
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: hokusai-sandbox
+      app: {{ project_name }}
       component: web
       layer: application
   strategy:
@@ -23,21 +25,22 @@ spec:
   template:
     metadata:
       labels:
-        app: hokusai-sandbox
+        app: {{ project_name }}
         component: web
         layer: application
-      name: hokusai-sandbox-web
+      name: {{ project_name }}-web
     spec:
       containers:
       - envFrom:
         - configMapRef:
-            name: hokusai-sandbox-environment
-        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/hokusai-sandbox:staging
+            name: {{ project_name }}-environment
+        image: {{ project_repo }}:staging
         imagePullPolicy: Always
-        name: hokusai-sandbox-web
+        name: {{ project_name }}-web
         ports:
         - name: http
           containerPort: 8080
+
 ---
 apiVersion: v1
 kind: Service
@@ -47,13 +50,13 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: 'true'
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: '443'
   labels:
-    app: hokusai-sandbox
+    app: {{ project_name }}
     component: web
     layer: application
-  name: hokusai-sandbox-web
+  name: {{ project_name }}-web
   namespace: default
 spec:
   ports:
@@ -66,7 +69,7 @@ spec:
     protocol: TCP
     targetPort: http
   selector:
-    app: hokusai-sandbox
+    app: {{ project_name }}
     component: web
     layer: application
   sessionAffinity: None


### PR DESCRIPTION
This should serve as a template for updating other apps

@eessex is the line `# prettier-ignore` at the beginning of Kubernetes Yaml files correct?

Merge once Hokusai version 0.5.8 is [released](https://github.com/artsy/hokusai/pull/192)