### PR TITLE
Test Client IP and headers behind Ingress controller

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -6,12 +6,35 @@ import (
 	"os"
 	"fmt"
 	"log"
+	"strings"
 	"net/http"
 	"time"
 	"github.com/streadway/amqp"
 )
 
+func formatRequest(r *http.Request) string {
+ // Create return string
+ var request []string
+ // Add the request string
+ url := fmt.Sprintf("%v %v %v", r.Method, r.URL, r.Proto)
+ request = append(request, url)
+ //  Add the Remote Address
+ request = append(request, fmt.Sprintf("Remote Address: %v", r.RemoteAddr))
+ // Add the host
+ request = append(request, fmt.Sprintf("Host: %v", r.Host))
+ // Add headers
+ for name, headers := range r.Header {
+   for _, h := range headers {
+     request = append(request, fmt.Sprintf("%v: %v", name, h))
+   }
+ }
+  // Return the request as a string
+  return strings.Join(request, ", ")
+}
+	
+
 func root(w http.ResponseWriter, r *http.Request) {
+	log.Printf(formatRequest(r))
 	fmt.Fprintf(w, "Hello, world!")
 }
 

--- a/hokusai/templates/service.yml.j2
+++ b/hokusai/templates/service.yml.j2
@@ -31,3 +31,44 @@ spec:
     layer: application
   sessionAffinity: None
   type: LoadBalancer
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ project_name }}
+    component: web
+    layer: application
+  name: {{ project_name }}-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: http
+  selector:
+    app: {{ project_name }}
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ project_name }}
+spec:
+  rules:
+    {%- if deployment_tag == 'staging' %}
+    - host: {{ project_name }}-staging.artsy.net
+    {%- else %}
+    - host: {{ project_name }}.artsy.net
+    {%- endif %}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ project_name }}-web-internal
+              servicePort: http


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2497 to test client ip preservation behind NLB and Nginx ingress controller

Log request data including client IP and headers. 

Add -web-internal service and Ingress resource