### PR TITLE
#Migration #WIP Ingress canary test.

### DIFF
--- a/hokusai/staging-ingress-canary.yml
+++ b/hokusai/staging-ingress-canary.yml
@@ -1,0 +1,80 @@
+# prettier-ignore
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hokusai-sandbox-web-canary
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hokusai-sandbox-canary
+      component: web
+      layer: application
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: hokusai-sandbox-canary
+        component: web
+        layer: application
+      name: hokusai-sandbox-web-canary
+    spec:
+      containers:
+      - env:
+          - name: PORT
+            value: "3000"
+        envFrom:
+        - configMapRef:
+            name: hokusai-sandbox-environment
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/hokusai-sandbox:staging
+        imagePullPolicy: Always
+        name: hokusai-sandbox-web
+        ports:
+        - name: http
+          containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hokusai-sandbox-canary
+    component: web
+    layer: application
+  name: hokusai-sandbox-web-internal-canary
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: http
+  selector:
+    app: hokusai-sandbox-canary
+    layer: application
+    component: web
+  type: ClusterIP
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: hokusai-sandbox-canary
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "10"
+spec:
+  rules:
+    - host: hokusai-sandbox-staging.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: hokusai-sandbox-web-internal-canary
+              servicePort: http
+


### PR DESCRIPTION
To test Ingress Canary feature: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#canary

Added a canary spec file that:

- Creates a canary deployment/service same as canonical deployment/service except for `-canary` labels.
- Creates a canary Ingress with annotations that tell Ingress Controller that this is a canary to the canonical ingress.

Migration (Applied)
---
```
kubectl --context staging create -f -f hokusai/staging-ingress-canary.yml
```

Test
---

Fired 10 HTTP GET's to `hokusai-sandbox-staging.artsy.net` marked with sequence numbers 0-9.

Sequence# 0-3, 5-9, are received by canonical ingress/service. That's 9 out of 10 requests, 90%.

```
Aug 15 11:09:38 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:38 +0000] "GET /?seq=0 HTTP/1.1" 200 13 "-" "Ruby" 154 0.000 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 5fb844e789aa2188faf7513a9df77299
Aug 15 11:09:40 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:40 +0000] "GET /?seq=1 HTTP/1.1" 200 13 "-" "Ruby" 154 0.000 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 598ff989054ff3ea4d5264933eb03c69
Aug 15 11:09:42 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:42 +0000] "GET /?seq=2 HTTP/1.1" 200 13 "-" "Ruby" 154 0.000 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 d2773be62ada8815ee3f384f77bfb0b3
Aug 15 11:09:44 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:44 +0000] "GET /?seq=3 HTTP/1.1" 200 13 "-" "Ruby" 154 0.001 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 a8edf1a064b0cc9945c28718929e49bb
Aug 15 11:09:48 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:48 +0000] "GET /?seq=5 HTTP/1.1" 200 13 "-" "Ruby" 154 0.000 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 0366e0ca3b7c3d0db4afc6783199046b
Aug 15 11:09:50 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:50 +0000] "GET /?seq=6 HTTP/1.1" 200 13 "-" "Ruby" 154 0.001 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 c207b740d34d87dcad42ffc07516c2a2
Aug 15 11:09:52 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:52 +0000] "GET /?seq=7 HTTP/1.1" 200 13 "-" "Ruby" 154 0.000 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 9bba1c883f2628478084fc9fef94ef35
Aug 15 11:09:55 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:54 +0000] "GET /?seq=8 HTTP/1.1" 200 13 "-" "Ruby" 154 0.001 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 b87d468323a76cda0578534f56f6da6b
Aug 15 11:09:57 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:57 +0000] "GET /?seq=9 HTTP/1.1" 200 13 "-" "Ruby" 154 0.001 [default-hokusai-sandbox-web-internal-http] [] 100.112.201.46:8080 13 0.000 200 7883b9dba323bb19fea2d2e990a51675
```

Sequence# 4 is received by canary ingress/service. 10%.

```
Aug 15 11:09:46 ingress-nginx-controller-m475b  173.68.205.200 - - [15/Aug/2020:15:09:46 +0000] "GET /?seq=4 HTTP/1.1" 200 13 "-" "Ruby" 154 0.000 [default-hokusai-sandbox-web-internal-http] [default-hokusai-sandbox-web-internal-canary-http] 100.112.201.58:3000 13 0.004 200 67e346f021fce404507e7a6f6e735978
```

Logs from the canary pod itself showing it received only seq#4:
```
$ kubectl --context staging logs hokusai-sandbox-web-canary-7f84789c67-frv2q | grep seq
2020/08/15 15:09:46 GET /?seq=4 HTTP/1.1, Remote Address: 100.112.201.52:33698, Host: hokusai-sandbox-staging.artsy.net, X-Real-Ip: 173.68.205.200, Accept: */*, Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3, X-Request-Id: 67e346f021fce404507e7a6f6e735978, X-Forwarded-For: 173.68.205.200, X-Forwarded-Host: hokusai-sandbox-staging.artsy.net, X-Forwarded-Port: 443, X-Forwarded-Proto: https, X-Scheme: https, User-Agent: Ruby
```