### PR TITLE
Switch off expired orbs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@dev:7140b0e073a71f7f54959c178c0caec5
-  artsy-remote-docker: artsy/remote-docker@dev:7140b0e073a71f7f54959c178c0caec5
+  hokusai: artsy/hokusai@0.7.5
+  artsy-remote-docker: artsy/remote-docker@0.1.6
 
 not_staging_or_release: &not_staging_or_release
   filters:


### PR DESCRIPTION
Previous merge caused `master` build to fail due to expired orbs. Correcting here.