### PR TITLE
fix: remove cron node affinity due to ebs volume in a zone where there are no background nodes.

### DIFF
--- a/bin/foo.sh
+++ b/bin/foo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 date >> /tmp/data/log.txt
 tail -2 /tmp/data/log.txt

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -143,13 +143,3 @@ spec:
             - name: data
               persistentVolumeClaim:
                 claimName: {{ project_name }}-cron-data
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: tier
-                        operator: In
-                        values:
-                          - background
-


### PR DESCRIPTION
fix: remove cron node affinity due to ebs volume in a zone where there are no background nodes.