### PR TITLE
feat: allow a delay to be specified in client request.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@2.1
+  hokusai: artsy/hokusai@0.10.0
   artsy-remote-docker: artsy/remote-docker@0.1.13
 
 not_staging_or_release: &not_staging_or_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@dev:04ff62549a4b112854e973eaf5c4dfff
+  hokusai: artsy/hokusai@2.1
   artsy-remote-docker: artsy/remote-docker@0.1.13
 
 not_staging_or_release: &not_staging_or_release

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@
 # use alternative ways to exclude files from git.
 # For example, set up .git/info/exclude or use a global .gitignore.
 .hokusai-tmp
-
-client
-server

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"fmt"
 	"log"
+        "strconv"
 	"strings"
 	"net/http"
 	"time"
@@ -29,10 +30,15 @@ func formatRequest(r *http.Request) string {
   // Return the request as a string
   return strings.Join(request, ", ")
 }
-	
 
 func root(w http.ResponseWriter, r *http.Request) {
 	log.Printf(formatRequest(r))
+        query := r.URL.Query()
+        delayparam, present := query["delay"] // delay=10
+        if present {
+          delay, _ := strconv.Atoi(delayparam[0])
+          time.Sleep(time.Duration(delay) * time.Second)
+        }
 	fmt.Fprintf(w, "Hello, world!")
 }
 


### PR DESCRIPTION
I want to run a pod in Kubernetes, that curls against an http server and waits. I want to see how that affects k8s cpu metric on that pod.

Don't see any off the shelf HTTP server that provides that testing feature, so adding it to hokusai-sandbox.

This allow clients to, for example:
```
curl hokusai-sandbox.artsy.net/?delay=10
```
and get a response after 10 seconds of wait.