### PR TITLE
test: pyyaml reformat hokusai specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@volatile
-  artsy-remote-docker: artsy/remote-docker@volatile
+  hokusai: artsy/hokusai@0.11.0
+  artsy-remote-docker: artsy/remote-docker@0.1.15
 
 not_staging_or_release: &not_staging_or_release
   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@0.11.0
-  artsy-remote-docker: artsy/remote-docker@0.1.15
+  hokusai: artsy/hokusai@volatile
+  artsy-remote-docker: artsy/remote-docker@volatile
 
 not_staging_or_release: &not_staging_or_release
   filters:

--- a/hokusai/production.yml.j2
+++ b/hokusai/production.yml.j2
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,6 +7,7 @@ metadata:
     app: {{ project_name }}
     component: web
     layer: application
+    app.kubernetes.io/version: production
 spec:
   replicas: 1
   selector:
@@ -26,23 +26,28 @@ spec:
         app: {{ project_name }}
         component: web
         layer: application
+        app.kubernetes.io/version: production
       name: {{ project_name }}-web
     spec:
       containers:
-        - name: {{ project_name }}-web
-          envFrom:
-            - configMapRef:
-                name: {{ project_name }}-environment
-          image: {{ project_repo }}:production
-          ports:
-          - name: http
-            containerPort: 8080
+      - name: {{ project_name }}-web
+        envFrom:
+        - configMapRef:
+            name: {{ project_name }}-environment
+        image: {{ project_repo }}:production
+        ports:
+        - name: http
+          containerPort: 8080
+        env:
+        - name: DD_VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
-          - name: ndots
-            value: "1"
-
+        - name: ndots
+          value: '1'
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -66,7 +71,6 @@ spec:
         averageUtilization: 70
         type: Utilization
     type: Resource
-
 ---
 apiVersion: v1
 kind: Service
@@ -79,63 +83,61 @@ metadata:
   namespace: default
 spec:
   ports:
-    - port: 8080
-      protocol: TCP
-      name: http
-      targetPort: http
+  - port: 8080
+    protocol: TCP
+    name: http
+    targetPort: http
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   type: ClusterIP
-
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ project_name }}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
 spec:
   ingressClassName: nginx
   rules:
-    - host: {{ project_name }}.artsy.net
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              serviceName: {{ project_name }}-web-internal
-              servicePort: http
-
+  - host: {{ project_name }}.artsy.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          serviceName: {{ project_name }}-web-internal
+          servicePort: http
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ project_name }}-cron
 spec:
-  schedule: "23 09 * * MON"
+  schedule: 23 09 * * MON
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
         spec:
           containers:
-            - name: {{ project_name }}-cron
-              image: {{ project_repo }}:staging
-              imagePullPolicy: Always
-              envFrom:
-                - configMapRef:
-                    name: {{ project_name }}-environment
-              args: ["hostname"]
+          - name: {{ project_name }}-cron
+            image: {{ project_repo }}:staging
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: {{ project_name }}-environment
+            args:
+            - hostname
           restartPolicy: Never
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: tier
-                        operator: In
-                        values:
-                          - background
-
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background

--- a/hokusai/production.yml.j2
+++ b/hokusai/production.yml.j2
@@ -8,7 +8,6 @@ metadata:
     app: {{ project_name }}
     component: web
     layer: application
-    app.kubernetes.io/version: production
 spec:
   replicas: 1
   selector:
@@ -27,16 +26,10 @@ spec:
         app: {{ project_name }}
         component: web
         layer: application
-        app.kubernetes.io/version: production
       name: {{ project_name }}-web
     spec:
       containers:
         - name: {{ project_name }}-web
-          env:
-            - name: DD_VERSION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['app.kubernetes.io/version']
           envFrom:
             - configMapRef:
                 name: {{ project_name }}-environment
@@ -44,7 +37,11 @@ spec:
           ports:
           - name: http
             containerPort: 8080
-{% filter indent(width=6, first=True) %}{% include 'templates/dns.yml.j2' %}{% endfilter %}
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
 
 ---
 apiVersion: autoscaling/v2beta2

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,6 +7,7 @@ metadata:
     app: {{ project_name }}
     component: web
     layer: application
+    app.kubernetes.io/version: staging
 spec:
   replicas: 1
   selector:
@@ -26,23 +26,28 @@ spec:
         app: {{ project_name }}
         component: web
         layer: application
+        app.kubernetes.io/version: staging
       name: {{ project_name }}-web
     spec:
       containers:
-        - name: {{ project_name }}-web
-          envFrom:
-            - configMapRef:
-                name: {{ project_name }}-environment
-          image: {{ project_repo }}:staging
-          ports:
-            - name: http
-              containerPort: 8080
+      - name: {{ project_name }}-web
+        envFrom:
+        - configMapRef:
+            name: {{ project_name }}-environment
+        image: {{ project_repo }}:staging
+        ports:
+        - name: http
+          containerPort: 8080
+        env:
+        - name: DD_VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
-          - name: ndots
-            value: "1"
-
+        - name: ndots
+          value: '1'
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -66,7 +71,6 @@ spec:
         averageUtilization: 70
         type: Utilization
     type: Resource
-
 ---
 apiVersion: v1
 kind: Service
@@ -79,62 +83,61 @@ metadata:
   namespace: default
 spec:
   ports:
-    - port: 8080
-      protocol: TCP
-      name: http
-      targetPort: http
+  - port: 8080
+    protocol: TCP
+    name: http
+    targetPort: http
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   type: ClusterIP
-
 ---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ project_name }}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
 spec:
   ingressClassName: nginx
   rules:
-    - host: {{ project_name }}-staging.artsy.net
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              serviceName: {{ project_name }}-web-internal
-              servicePort: http
-
+  - host: {{ project_name }}-staging.artsy.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          serviceName: {{ project_name }}-web-internal
+          servicePort: http
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ project_name }}-cron
 spec:
-  schedule: "23 09 * * MON"
+  schedule: 23 09 * * MON
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
         spec:
           containers:
-            - name: {{ project_name }}-cron
-              image: {{ project_repo }}:staging
-              imagePullPolicy: Always
-              envFrom:
-                - configMapRef:
-                    name: {{ project_name }}-environment
-              args: ["hostname"]
+          - name: {{ project_name }}-cron
+            image: {{ project_repo }}:staging
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: {{ project_name }}-environment
+            args:
+            - hostname
           restartPolicy: Never
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: tier
-                        operator: In
-                        values:
-                          - background
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -8,7 +8,6 @@ metadata:
     app: {{ project_name }}
     component: web
     layer: application
-    app.kubernetes.io/version: staging
 spec:
   replicas: 1
   selector:
@@ -27,16 +26,10 @@ spec:
         app: {{ project_name }}
         component: web
         layer: application
-        app.kubernetes.io/version: staging
       name: {{ project_name }}-web
     spec:
       containers:
         - name: {{ project_name }}-web
-          env:
-            - name: DD_VERSION
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['app.kubernetes.io/version']
           envFrom:
             - configMapRef:
                 name: {{ project_name }}-environment
@@ -44,7 +37,11 @@ spec:
           ports:
             - name: http
               containerPort: 8080
-{% filter indent(width=6, first=True) %}{% include 'templates/dns.yml.j2' %}{% endfilter %}
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
 
 ---
 apiVersion: autoscaling/v2beta2

--- a/hokusai/templates/dns.yml.j2
+++ b/hokusai/templates/dns.yml.j2
@@ -1,5 +1,0 @@
-dnsPolicy: ClusterFirst
-dnsConfig:
-  options:
-    - name: ndots
-      value: "1"


### PR DESCRIPTION
The changes are just reformatting done by PyYAML.

poor yaml -> PyYAML -> better yaml (correcting indentation, removing un-necessary double quotes)

Only real change is making `dns.yml` content inline in hokusai specs, rather than pulling it in via Jinja.

It seems templating specs is not worth the while. Makes the specs not valid yaml. I worked around the `{{ ` and ` }}` with `sed` (cleaning them out before PyYAML, and adding them back after). Could not work around the `dns.yml` line so removing it.