### PR TITLE
feat: pull secrets from vault

### DIFF
--- a/hokusai/production.yml.j2
+++ b/hokusai/production.yml.j2
@@ -1,3 +1,37 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: hokusai-sandbox
+spec:
+  refreshInterval: "5m"
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: hokusai-sandbox
+    creationPolicy: Owner
+    deletionPolicy: Merge
+    template:
+      engineVersion: v2
+      templateFrom:
+      - target: Data
+        {% raw %}
+        literal: |
+          {{ range $key, $value := . }}
+          {{$key}}: {{$value | fromJson | values | first}}
+          {{ end }}
+        {% endraw %}
+  dataFrom:
+  - find:
+      name:
+        regexp: "kubernetes/apps/hokusai-sandbox/*"
+    rewrite:
+    - regexp:
+        source: "kubernetes/apps/hokusai-sandbox/(.*)"
+        target: "$1"
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,6 +68,8 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ project_name }}-environment
+        - secretRef:
+            name: hokusai-sandbox
         image: {{ project_repo }}:production
         ports:
         - name: sandbox-http

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -10,9 +10,13 @@ spec:
   target:
     name: hokusai-sandbox
     creationPolicy: Owner
-  dataFrom:
-    - extract:
-        key: kubernetes/apps/hokusai-sandbox/secrets
+  data:
+  - secretKey: key3
+    remoteRef:
+      key: kubernetes/apps/hokusai-sandbox/key3
+  - secretKey: key4
+    remoteRef:
+      key: kubernetes/apps/hokusai-sandbox/key4
 
 ---
 apiVersion: apps/v1

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -10,6 +10,7 @@ spec:
   target:
     name: hokusai-sandbox
     creationPolicy: Owner
+    deletionPolicy: Merge
     template:
       engineVersion: v2
       templateFrom:

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: hokusai-sandbox
 spec:
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     name: vault
     kind: ClusterSecretStore
@@ -11,10 +11,10 @@ spec:
     name: hokusai-sandbox
     creationPolicy: Owner
   data:
-  - secretKey: name
+  - secretKey: key1
     remoteRef:
-      key: hokusai-sandbox
-      property: name
+      key: kubernetes/apps/hokusai-sandbox/secrets
+      property: key1
 
 ---
 apiVersion: apps/v1

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -53,6 +53,8 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ project_name }}-environment
+        - secretRef:
+            name: hokusai-sandbox
         image: {{ project_repo }}:staging
         ports:
         - name: sandbox-http

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -10,13 +10,11 @@ spec:
   target:
     name: hokusai-sandbox
     creationPolicy: Owner
-  data:
-  - secretKey: key3
-    remoteRef:
-      key: kubernetes/apps/hokusai-sandbox/key3
-  - secretKey: key4
-    remoteRef:
-      key: kubernetes/apps/hokusai-sandbox/key4
+  dataFrom:
+    - extract:
+        key: kubernetes/apps/hokusai-sandbox/key3
+    - extract:
+        key: kubernetes/apps/hokusai-sandbox/key4
 
 ---
 apiVersion: apps/v1

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -10,6 +10,16 @@ spec:
   target:
     name: hokusai-sandbox
     creationPolicy: Owner
+    template:
+      engineVersion: v2
+      templateFrom:
+      - target: Data
+        {% raw %}
+        literal: |
+          {{ range $key, $value := . }}
+          {{$key | upper}}: ${{$value}}
+          {{ end }}
+        {% endraw %}
   dataFrom:
   - find:
       name:

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -11,10 +11,13 @@ spec:
     name: hokusai-sandbox
     creationPolicy: Owner
   dataFrom:
-    - extract:
-        key: kubernetes/apps/hokusai-sandbox/key3
-    - extract:
-        key: kubernetes/apps/hokusai-sandbox/key4
+  - find:
+      name:
+        regexp: "kubernetes/apps/hokusai-sandbox/*"
+    rewrite:
+    - regexp:
+        source: "kubernetes/apps/hokusai-sandbox/(.*)"
+        target: "$1"
 
 ---
 apiVersion: apps/v1

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -17,7 +17,7 @@ spec:
         {% raw %}
         literal: |
           {{ range $key, $value := . }}
-          {{$key | upper}}: ${{$value}}
+          {{$key}}: {{$value | fromJson | values | first}}
           {{ end }}
         {% endraw %}
   dataFrom:

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -10,11 +10,9 @@ spec:
   target:
     name: hokusai-sandbox
     creationPolicy: Owner
-  data:
-  - secretKey: key1
-    remoteRef:
-      key: kubernetes/apps/hokusai-sandbox/secrets
-      property: key1
+  dataFrom:
+    - extract:
+        key: kubernetes/apps/hokusai-sandbox/secrets
 
 ---
 apiVersion: apps/v1

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -1,3 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: hokusai-sandbox
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: hokusai-sandbox
+    creationPolicy: Owner
+  data:
+  - secretKey: name
+    remoteRef:
+      key: hokusai-sandbox
+      property: name
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: hokusai-sandbox
 spec:
-  refreshInterval: "0"
+  refreshInterval: "5m"
   secretStoreRef:
     name: vault
     kind: ClusterSecretStore

--- a/hokusai/staging.yml.j2
+++ b/hokusai/staging.yml.j2
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: hokusai-sandbox
 spec:
-  refreshInterval: 5m
+  refreshInterval: "0"
   secretStoreRef:
     name: vault
     kind: ClusterSecretStore


### PR DESCRIPTION
Take project's secret configs stored in Vault, and inject them into pods' env. Please see [Notion doc](https://www.notion.so/artsy/Hashicorp-Vault-77d94af51f714d51bb44049f4f2027bc#c7cfa6fbb0b949b28efbd678ae197621) for context.

- Add ExternalSecret which will pull project's secrets from Vault and store them in a k8s secret.
- Add secretRef which will inject the contents of that k8s secret into pods' env.