### PR TITLE
feat: use init container to load secrets from vault [do-not-merge] [spike]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ENV PORT 8080
 EXPOSE 8080
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["./server"]
+CMD ["./start_server.sh"]

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -1,36 +1,3 @@
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: hokusai-sandbox
-spec:
-  refreshInterval: "5m"
-  secretStoreRef:
-    name: vault
-    kind: ClusterSecretStore
-  target:
-    name: hokusai-sandbox
-    creationPolicy: Owner
-    deletionPolicy: Merge
-    template:
-      engineVersion: v2
-      templateFrom:
-      - target: Data
-        {% raw %}
-        literal: |
-          {{ range $key, $value := . }}
-          {{$key}}: {{$value | fromJson | values | first}}
-          {{ end }}
-        {% endraw %}
-  dataFrom:
-  - find:
-      path: kubernetes/apps/hokusai-sandbox
-      name:
-        regexp: ".*"
-    rewrite:
-    - regexp:
-        source: "kubernetes/apps/hokusai-sandbox/(.*)"
-        target: "$1"
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -63,13 +30,22 @@ spec:
         app.kubernetes.io/version: staging
       name: {{ project_name }}-web
     spec:
+      initContainers:
+      - name: setenv
+        image: busybox
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "FOO=bar" >> /tmp/env/file
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp/env
       containers:
       - name: {{ project_name }}-web
         envFrom:
         - configMapRef:
             name: {{ project_name }}-environment
-        - secretRef:
-            name: hokusai-sandbox
         image: {{ project_repo }}:staging
         imagePullPolicy: Always
         ports:
@@ -94,6 +70,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['app.kubernetes.io/version']
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp/env
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -114,6 +93,9 @@ spec:
                 values:
                 - foreground
                 - foreground-spot
+      volumes:
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -32,12 +32,23 @@ spec:
     spec:
       initContainers:
       - name: setenv
-        image: busybox
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:jian-test
         command:
-        - /bin/sh
-        - -c
-        - |
-          echo "FOO=bar" >> /tmp/env/file
+        - python
+        - src/load_secrets_from_vault/load.py
+        - staging
+        - hokusai-sandbox
+        env:
+        - name: PORT
+          value: "8080"
+        - name: VAULT_HOST
+          value: "vault.stg.artsy.systems"
+        - name: VAULT_PORT
+          value: "8200"
+        - name: VAULT_KVV2_MOUNT_POINT
+          value: "kvv2"
+        - name: SECRETS_FILE
+          value: "/tmp/env/file"
         volumeMounts:
         - name: tmp
           mountPath: /tmp/env
@@ -78,6 +89,7 @@ spec:
         options:
         - name: ndots
           value: '1'
+      serviceAccountName: hokusai-sandbox
       tolerations:
         - key: reserved
           operator: Equal

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 export $(cat /tmp/env/file | xargs)
 env
+rm /tmp/env/file
 ./server

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 export $(cat /tmp/env/file | xargs)
 env
-rm /tmp/env/file
+#rm /tmp/env/file
 ./server

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+export $(cat /tmp/env/file | xargs)
+./server

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 export $(cat /tmp/env/file | xargs)
+env
 ./server


### PR DESCRIPTION
[PHIRE-1049]

This is a demonstration/spike PR.

Currently, the app's secrets are fetched from Vault using an `ExternalSecret` resource.

This PR demonstrates an alternative - using an [Init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that runs a custom script (from Opstools repo). The script fetches secrets from Vault, writes them to a file that is stored in a volume shared between the Init container and the main container. Main container's Docker CMD is modified to run a script that reads the secrets file and then starts service.

Related changes from other repos:

- [Opstools](https://github.com/artsy/opstools/compare/artsyjian/vault?expand=1)
  The custom script that loads the secrets.
- [Substance](https://github.com/artsy/substance/compare/artsyjian/vault?expand=1)
  Create K8S service account for sandbox app. The custom script logs into Vault using the JWT that's associated with that service account.
- [Infrastructure](https://github.com/artsy/infrastructure/compare/artsyjian/vault?expand=1)
  Create Vault role and permissions for sandbox app.

It works:
```
artsy:~ jxu$ vault kv list kvv2/kubernetes/apps/hokusai-sandbox/                                                                         
Keys
----
BAR
BAZ

ip-192-168-1-18:~ jxu$ kubectl --context staging logs hokusai-sandbox-web-6ddc8579cb-mnw2c | grep -vi service | grep -vi port
...
BAR=fin
...
BAZ=boo
...
```

Implications of this approach:

- For each K8S artsy app, we must create:
  - a K8S service account, and associate it with [dockerhub creds](https://github.com/artsy/substance/blob/b3608d53e8e518542c8e8cbcdca642b723c733c5/services/service-accounts.yml#L8).
  - a Vault role/policy.
- When we exec into app container, we no longer can see the secret vars via `env` shell command. This is because `start_server.sh` runs in a subshell. I don't know of a way to show env of a sub-shell. This may make troubleshooting hard, but at the same time, it may be more secure.
- Secrets file is stored on disk, but `start_server.sh` can delete it after populating env. Or we can explore in-memory only volumes.
- Hokusai specs of every K8S app will have to be updated similarly.