### PR TITLE
feat: use init container to load secrets from vault [spike#3]

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -32,7 +32,7 @@ spec:
     spec:
       initContainers:
       - name: setenv
-        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:jian-test
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
         imagePullPolicy: Always
         command:
         - python

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -52,7 +52,7 @@ spec:
         args:
         - sh
         - -c
-        - export $(cat /secrets/secrets | xargs) && ./server
+        - source /secrets/secrets && ./server
         image: {{ project_repo }}:staging
         imagePullPolicy: Always
         ports:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -33,6 +33,7 @@ spec:
       initContainers:
       - name: setenv
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:jian-test
+        imagePullPolicy: Always
         command:
         - python
         - src/load_secrets_from_vault/load.py


### PR DESCRIPTION
Supports [PHIRE-1097]
Follows https://github.com/artsy/hokusai-sandbox/pull/73

`export $(cat /secrets/secrets | xargs` does not work with secret values that are multi-line'd. Force' `APPLE_PRIVATE_KEY` is one such.

This PR switches to using `source`. Together with https://github.com/artsy/opstools/pull/104 which changes `load_secrets_from_vault`'s output file to the following format:

```
export FOO='bar'
export BAR='foo'
```

The problem with multi-line values is solved.

[PHIRE-1097]: https://artsyproduct.atlassian.net/browse/PHIRE-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ