### PR TITLE
feat: use init container to load secrets from vault [spike#4]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN go build src/server/server.go
 ENV PORT 8080
 EXPOSE 8080
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "./load_secrets_and_run.sh"]
 CMD ["./server"]

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,38 +1,4 @@
 ---
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: hokusai-sandbox
-spec:
-  refreshInterval: "5m"
-  secretStoreRef:
-    name: vault
-    kind: ClusterSecretStore
-  target:
-    name: hokusai-sandbox
-    creationPolicy: Owner
-    deletionPolicy: Merge
-    template:
-      engineVersion: v2
-      templateFrom:
-      - target: Data
-        {% raw %}
-        literal: |
-          {{ range $key, $value := . }}
-          {{$key}}: {{$value | fromJson | values | first}}
-          {{ end }}
-        {% endraw %}
-  dataFrom:
-  - find:
-      path: kubernetes/apps/hokusai-sandbox
-      name:
-        regexp: ".*"
-    rewrite:
-    - regexp:
-        source: "kubernetes/apps/hokusai-sandbox/(.*)"
-        target: "$1"
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -64,13 +30,26 @@ spec:
         app.kubernetes.io/version: production
       name: {{ project_name }}-web
     spec:
+      initContainers:
+      - name: setenv
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
+        imagePullPolicy: Always
+        command:
+        - python
+        - src/load_secrets_from_vault/load.py
+        - production
+        - hokusai-sandbox
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
       containers:
       - name: {{ project_name }}-web
         envFrom:
         - configMapRef:
             name: {{ project_name }}-environment
-        - secretRef:
-            name: hokusai-sandbox
         image: {{ project_repo }}:production
         imagePullPolicy: Always
         ports:
@@ -95,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['app.kubernetes.io/version']
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -50,10 +50,6 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ project_name }}-environment
-        args:
-        - sh
-        - -c
-        - source /secrets/secrets && ./server
         image: {{ project_repo }}:staging
         imagePullPolicy: Always
         ports:

--- a/load_secrets_and_run.sh
+++ b/load_secrets_and_run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+CMD=$1
+echo "$CMD"
+source /secrets/secrets
+"$CMD"
+

--- a/load_secrets_and_run.sh
+++ b/load_secrets_and_run.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
-CMD=$1
-echo "$CMD"
-source /secrets/secrets
-"$CMD"
+CMD="$@"
 
+SECRETS_FILE_DIR=/secrets
+
+if [ -d "$SECRETS_FILE_DIR" ]
+then
+  echo "Sourcing secrets file..."
+  source "$SECRETS_FILE_DIR/secrets"
+fi
+
+echo "Running command: $CMD"
+$CMD

--- a/load_secrets_and_run.sh
+++ b/load_secrets_and_run.sh
@@ -1,3 +1,14 @@
 #!/bin/sh
 
-./test_sig.sh
+CMD="$@"
+
+SECRETS_FILE_DIR=/secrets
+
+if [ -d "$SECRETS_FILE_DIR" ]
+then
+  echo "Sourcing secrets file..."
+  source "$SECRETS_FILE_DIR/secrets"
+fi
+
+echo "Running command: $CMD"
+$CMD

--- a/load_secrets_and_run.sh
+++ b/load_secrets_and_run.sh
@@ -1,14 +1,3 @@
 #!/bin/sh
 
-CMD="$@"
-
-SECRETS_FILE_DIR=/secrets
-
-if [ -d "$SECRETS_FILE_DIR" ]
-then
-  echo "Sourcing secrets file..."
-  source "$SECRETS_FILE_DIR/secrets"
-fi
-
-echo "Running command: $CMD"
-$CMD
+./test_sig.sh

--- a/test_sig.sh
+++ b/test_sig.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+trap "echo eating sigterm; exit" SIGTERM
+
+while true
+do
+  sleep 5
+done

--- a/test_sig.sh
+++ b/test_sig.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-trap "echo eating sigterm; exit" SIGTERM
-
-while true
-do
-  sleep 5
-done


### PR DESCRIPTION
[PHIRE-1086]

Follows https://github.com/artsy/hokusai-sandbox/pull/74

Introduce a shell script to be called by `dumb-init` at `ENTRYPOINT`. Script loads secrets file and runs the command specified by script's first argument which by defeault is Dockerfile `CMD`.

Kubernetes pod spec's `arg` overwrites Docker `CMD`, so this works with `hokusai ... run <command>` too, as long as [Hokusai includes initContainer spec in its overrides](https://github.com/artsy/hokusai/pull/419).

Requires https://github.com/artsy/hokusai/pull/419 to be merged first.

[PHIRE-1086]: https://artsyproduct.atlassian.net/browse/PHIRE-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ