### PR TITLE
feat: use init container to load secrets from vault [spike#5]

### DIFF
--- a/load_secrets_and_run.sh
+++ b/load_secrets_and_run.sh
@@ -2,12 +2,10 @@
 
 CMD="$@"
 
-SECRETS_FILE_DIR=/secrets
-
-if [ -d "$SECRETS_FILE_DIR" ]
+if [ ! -z "$SECRETS_FILE" ]
 then
-  echo "Sourcing secrets file..."
-  source "$SECRETS_FILE_DIR/secrets"
+  echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
+  source "$SECRETS_FILE"
 fi
 
 echo "Running command: $CMD"


### PR DESCRIPTION
Follows https://github.com/artsy/hokusai-sandbox/pull/75

Instead of hardcoding file path in script, take it from `SECRETS_FILE` var, and if that var is not NULL, do load file.

```
artsy:hokusai-sandbox jxu$ hokusai staging env get SECRETS_FILE | cut -f1 -d=
SECRETS_FILE
```