### PR TITLE
feat: migrate ingress to new controllers (staging)

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -154,27 +154,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ project_name }}
-  annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: {{ project_name }}-staging.artsy.net
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ project_name }}-web-internal
-            port:
-              name: http
-
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: {{ project_name }}-2025
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}


### PR DESCRIPTION
The existing ingress controllers are not scalable. We have [created a new set of Ingress Controllers](https://github.com/artsy/substance/pull/420) that are scalable.

We want to migrate the ingress to the new controllers without disruption to traffic.

This PR adds a parallel ingress that is tied to the new controllers.

After Staging deploy:

- [x] Point the app's DNS to the new controllers. This should be done via Infrastructure repo. (This is actually [done](https://github.com/artsy/infrastructure/pull/891) already. We migrated this app as PoC.)
- [x] Verify that the app still works.
- [x] Delete the old ingress via kubectl. (`kubectl --context staging delete ingress <old-ingress-name>`)